### PR TITLE
[hotfix] [flink-table/flink-table-planner] Fix flaky test

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDmlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDmlToOperationConverterTest.java
@@ -106,7 +106,7 @@ public class SqlDmlToOperationConverterTest extends SqlNodeToOperationConversion
         Map<String, String> dynamicOptions = sinkModifyOperation.getDynamicOptions();
         assertThat(dynamicOptions).isNotNull();
         assertThat(dynamicOptions.size()).isEqualTo(2);
-        assertThat(dynamicOptions.toString()).isEqualTo("{k1=v1, k2=v2}");
+        assertThat(dynamicOptions.toString()).isIn("{k1=v1, k2=v2}", "{k2=v2, k1=v1}");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
This pull request updates the test which is detected as flaky. The original test uses Map, which does not have an order for the elements. When calling the toString() function, the result will be in an undetermined order. It can be either "{k1=v1, k2=v2}" or "{k2=v2, k1=v1}". The updated test uses "isIn" to check if the result is in any of the two cases.

## Brief change log
 - change "isEqualTo" to "isIn", adding another possible result "{k2=v2, k1=v1}".


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
